### PR TITLE
fixed malware link

### DIFF
--- a/witch/webroot/index.html
+++ b/witch/webroot/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <!-- 引入样式 -->
-    <link rel="stylesheet" href="http://cdn.jsdeliver.net/npm/element-ui/lib/theme-chalk/index.css">
+    <link rel="stylesheet" href="http://cdn.jsdelivr.net/npm/element-ui/lib/theme-chalk/index.css">
     <style>
         body {
             font-family: Helvetica


### PR DESCRIPTION
jsdeliver.net is a fake malware website. The real CDN is
jsdelivr.net

Note the additional e. In this case the fake URL was responding with 404 but it still needed fixing to avoid future problems.