### PR TITLE
adding support for arm64 based on modern-go/gls

### DIFF
--- a/gls/goid_arm64.s
+++ b/gls/goid_arm64.s
@@ -1,0 +1,12 @@
+// Copyright 2016 Huan Du. All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+
+#include "go_asm.h"
+#include "textflag.h"
+
+TEXT ·getg(SB), NOSPLIT, $0-8
+    MOVD    g, R8
+    MOVD    R8, ret+0(FP)
+    RET
+


### PR DESCRIPTION
This makes it possible to compile packages depending on `gls` on Apple silicon.

original source: https://raw.githubusercontent.com/modern-go/gls/master/goid_arm64.s