### PR TITLE
Add riscv64 support

### DIFF
--- a/gls/goid_riscv64.s
+++ b/gls/goid_riscv64.s
@@ -1,0 +1,11 @@
+// Copyright 2016 Huan Du. All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+
+#include "go_asm.h"
+#include "textflag.h"
+
+TEXT ·getg(SB), NOSPLIT, $0-8
+    MOV    g, A0
+    MOV    A0, ret+0(FP)
+    RET


### PR DESCRIPTION
Upstreamed from https://github.com/felixonmars/archriscv-packages/commit/223fd23123026c14a7a6431caf882911547896aa

Thanks @Ast-x64 for their effort.